### PR TITLE
Improve mobile responsiveness for navbar and expert pages

### DIFF
--- a/client/src/components.d.ts
+++ b/client/src/components.d.ts
@@ -1,0 +1,4 @@
+declare module "*.jsx" {
+  const content: any;
+  export default content;
+}

--- a/client/src/components/ExpertEcommerce.jsx
+++ b/client/src/components/ExpertEcommerce.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useLocation } from 'wouter';
-import { ArrowLeft, Bell, Send } from 'lucide-react';
+import { ArrowLeft, Bell, Send, X } from 'lucide-react';
 import { findAnswer } from '../data/questionsAnswers';
 import ImageModal from './ImageModal';
 
@@ -37,6 +37,7 @@ const ExpertEcommerce = () => {
   const [currentThreadId, setCurrentThreadId] = useState(null);
 
   const [imageModal, setImageModal] = useState({ isOpen: false, src: '', alt: '' });
+  const [activeAnswerIndex, setActiveAnswerIndex] = useState(null);
 
   useEffect(() => {
     const user = JSON.parse(localStorage.getItem('currentUser'));
@@ -109,9 +110,51 @@ const ExpertEcommerce = () => {
       ...msg,
       timestamp: new Date(msg.timestamp)
     })));
-    setAnswers(thread.answers);
+  setAnswers(thread.answers);
   };
 
+
+  const getPreviewText = (answer) => {
+    if (!answer) return '';
+    if (answer.isOutOfExpertise) return answer.message;
+    const text =
+      answer.solutionApproach ||
+      answer.implementationTipsOrPitfalls ||
+      '';
+    return text.length > 80 ? text.slice(0, 80) + '…' : text;
+  };
+
+  const renderAnswerModal = (answer) => {
+    if (!answer) return null;
+    if (answer.isOutOfExpertise) {
+      return <p className="text-center">{answer.message}</p>;
+    }
+    return (
+      <div className="space-y-6 text-left">
+        {answer.title && <h2 className="text-xl font-bold mb-2">{answer.title}</h2>}
+        <div>
+          <h3 className="font-semibold mb-1">1. Business Context</h3>
+          <p>{answer.businessContext}</p>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">2. Technology Overview</h3>
+          <p>{answer.technologyOverview}</p>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">3. Solution Approach</h3>
+          <div className="whitespace-pre-line">{answer.solutionApproach}</div>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">4. Real-world Tools or Examples</h3>
+          <div className="whitespace-pre-line">{answer.realWorldToolsOrExamples}</div>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">5. Implementation Tips or Pitfalls</h3>
+          <p>{answer.implementationTipsOrPitfalls}</p>
+        </div>
+      </div>
+    );
+  };
 
 
   const handleQuestionSubmit = (question) => {
@@ -123,14 +166,37 @@ const ExpertEcommerce = () => {
     };
 
     const newMessages = [...messages, userMessage];
-    setMessages(newMessages);
     setAttachedFiles([]);
 
-    // Get answer immediately
     const result = findAnswer(question, 'ecommerce');
     const newAnswers = [...answers, result.answer];
+    const answerIndex = newAnswers.length - 1;
+    const previewText = getPreviewText(result.answer);
+
+    let finalMessages = [...newMessages];
+    const refinedQuery = generateRefinedQuery(question, result.answer);
+    if (refinedQuery) {
+      finalMessages.push({
+        text: refinedQuery,
+        isUser: false,
+        timestamp: new Date(),
+        isRefinement: true,
+        answerIndex,
+        previewText
+      });
+    } else {
+      finalMessages.push({
+        text: "I've analyzed your question and prepared a detailed strategy.",
+        isUser: false,
+        timestamp: new Date(),
+        answerIndex,
+        previewText
+      });
+    }
+
+    setMessages(finalMessages);
     setAnswers(newAnswers);
-    saveChatHistory(newMessages, newAnswers);
+    saveChatHistory(finalMessages, newAnswers);
   };
 
   const handleSendMessage = (messageText = currentMessage) => {
@@ -176,13 +242,13 @@ const ExpertEcommerce = () => {
 
       <div className="flex-1 flex overflow-hidden">
         {/* Left Chat Panel */}
-        <div className="w-[30%] bg-card border-r border-border flex flex-col">
+        <div className={`w-full md:w-[30%] bg-card border-r border-border flex flex-col ${activeAnswerIndex !== null ? 'filter blur-sm' : ''}`}>
           {/* Chat Controls */}
           <div className="p-4 border-b border-border">
-            <div className="flex space-x-2 mb-4">
+            <div className="flex flex-wrap gap-2 mb-4">
               <NewChatCard onClick={startNewChat} />
-              <SearchHistoryCard 
-                chatThreads={chatThreads} 
+              <SearchHistoryCard
+                chatThreads={chatThreads}
                 onSelectThread={selectThread}
                 onDeleteThread={(threadId) => {
                   const updatedThreads = chatThreads.filter(t => t.id !== threadId);
@@ -217,10 +283,10 @@ const ExpertEcommerce = () => {
                       </div>
                     )}
                     
-                    <div className={`flex ${message.isUser ? 'justify-end' : 'justify-start'}`}>
+                    <div className={`flex ${message.isUser ? 'justify-end' : 'justify-start'}`}> 
                   <div className={`max-w-[85%] p-3 rounded-2xl ${
-                    message.isUser 
-                      ? 'bg-primary text-primary-foreground ml-4' 
+                    message.isUser
+                      ? 'bg-primary text-primary-foreground ml-4'
                       : message.isRefinement
                       ? 'bg-secondary/20 text-secondary border border-secondary/30 mr-4'
                       : 'bg-accent text-accent-foreground mr-4'
@@ -236,6 +302,14 @@ const ExpertEcommerce = () => {
                     </div>
                   </div>
                     </div>
+                    {!message.isUser && message.answerIndex !== undefined && (
+                      <button
+                        onClick={() => setActiveAnswerIndex(message.answerIndex)}
+                        className="md:hidden mt-2 ml-4 w-[85%] text-left text-sm bg-muted p-3 rounded-lg"
+                      >
+                        {message.previewText}
+                      </button>
+                    )}
                   </div>
                 );
               })}
@@ -265,7 +339,7 @@ const ExpertEcommerce = () => {
         </div>
 
         {/* Right Preview Panel */}
-        <div className="flex-1 bg-background overflow-y-auto p-6">
+        <div className="hidden md:flex md:flex-1 bg-background overflow-y-auto p-6">
           {answers.length === 0 ? (
             <div className="h-full flex items-center justify-center">
               <div className="text-center max-w-2xl">
@@ -401,7 +475,7 @@ const ExpertEcommerce = () => {
           )}
 
           {/* Image Modal */}
-          <ImageModal 
+          <ImageModal
             isOpen={imageModal.isOpen}
             onClose={() => setImageModal({ isOpen: false, src: '', alt: '' })}
             imageSrc={imageModal.src}
@@ -410,11 +484,25 @@ const ExpertEcommerce = () => {
         </div>
       </div>
 
+      {activeAnswerIndex !== null && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
+          <div className="bg-card w-[90%] max-h-[90vh] overflow-y-auto rounded-lg p-6 relative">
+            <button
+              onClick={() => setActiveAnswerIndex(null)}
+              className="absolute top-4 right-4 text-muted-foreground"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            {renderAnswerModal(answers[activeAnswerIndex])}
+          </div>
+        </div>
+      )}
+
       {/* Bell Inbox Modal */}
-      <BellInbox 
-        isOpen={showInbox} 
-        onClose={() => setShowInbox(false)} 
-        messages={messages} 
+      <BellInbox
+        isOpen={showInbox}
+        onClose={() => setShowInbox(false)}
+        messages={messages}
         answers={answers} 
       />
     </div>

--- a/client/src/components/ExpertPython.jsx
+++ b/client/src/components/ExpertPython.jsx
@@ -1,6 +1,6 @@
 import { useState, useEffect } from 'react';
 import { useLocation } from 'wouter';
-import { ArrowLeft, Bell, Send } from 'lucide-react';
+import { ArrowLeft, Bell, Send, X } from 'lucide-react';
 import { findAnswer } from '../data/questionsAnswers';
 
 // Helper function to generate refined queries
@@ -35,6 +35,7 @@ const ExpertPython = () => {
   const [chatThreads, setChatThreads] = useState([]);
   const [currentThreadId, setCurrentThreadId] = useState(null);
   const [isLoading, setIsLoading] = useState(false);
+  const [activeAnswerIndex, setActiveAnswerIndex] = useState(null);
 
 
   useEffect(() => {
@@ -112,6 +113,49 @@ const ExpertPython = () => {
   };
 
 
+  const getPreviewText = (answer) => {
+    if (!answer) return '';
+    if (answer.isOutOfExpertise) return answer.message;
+    const text =
+      answer.summaryOrRecommendation ||
+      answer.stepByStepSolution ||
+      '';
+    return text.length > 80 ? text.slice(0, 80) + '…' : text;
+  };
+
+  const renderAnswerModal = (answer) => {
+    if (!answer) return null;
+    if (answer.isOutOfExpertise) {
+      return <p className="text-center">{answer.message}</p>;
+    }
+    return (
+      <div className="space-y-6 text-left">
+        {answer.title && <h2 className="text-xl font-bold mb-2">{answer.title}</h2>}
+        <div>
+          <h3 className="font-semibold mb-1">1. Problem Overview</h3>
+          <p>{answer.problemOverview}</p>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">2. Core Concept Explanation</h3>
+          <p>{answer.coreConceptExplanation}</p>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">3. Step-by-Step Solution</h3>
+          <pre className="bg-muted p-4 rounded text-sm overflow-x-auto whitespace-pre-wrap"><code>{answer.stepByStepSolution}</code></pre>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">4. Gotchas or Common Pitfalls</h3>
+          <p>{answer.gotchasOrPitfalls}</p>
+        </div>
+        <div>
+          <h3 className="font-semibold mb-1">5. Summary or Recommendation</h3>
+          <p>{answer.summaryOrRecommendation}</p>
+        </div>
+      </div>
+    );
+  };
+
+
 
   const getRefinedQuery = (question, attachedFiles = []) => {
     // Check if image contains UnboundLocalError code
@@ -149,7 +193,13 @@ const ExpertPython = () => {
     // Show loading for 2 seconds, then show refined query and answer
     setTimeout(() => {
       let newMessages = [...messages, userMessage];
-      
+
+      // Get answer
+      const result = findAnswer(question, 'python');
+      const newAnswers = [...answers, result.answer];
+      const answerIndex = newAnswers.length - 1;
+      const previewText = getPreviewText(result.answer);
+
       // Add refined query if available
       const refinedQuery = getRefinedQuery(question, userMessage.attachedFiles);
       if (refinedQuery) {
@@ -157,16 +207,23 @@ const ExpertPython = () => {
           text: refinedQuery,
           isUser: false,
           timestamp: new Date(),
-          isRefinement: true
+          isRefinement: true,
+          answerIndex,
+          previewText
         };
         newMessages = [...newMessages, refinementMessage];
+      } else {
+        const responseMessage = {
+          text: "I've analyzed your question and prepared a detailed response.",
+          isUser: false,
+          timestamp: new Date(),
+          answerIndex,
+          previewText
+        };
+        newMessages = [...newMessages, responseMessage];
       }
 
       setMessages(newMessages);
-
-      // Get answer
-      const result = findAnswer(question, 'python');
-      const newAnswers = [...answers, result.answer];
       setAnswers(newAnswers);
       setIsLoading(false);
       saveChatHistory(newMessages, newAnswers);
@@ -216,13 +273,13 @@ const ExpertPython = () => {
 
       <div className="flex-1 flex overflow-hidden">
         {/* Left Chat Panel */}
-        <div className="w-[30%] bg-card border-r border-border flex flex-col">
+        <div className={`w-full md:w-[30%] bg-card border-r border-border flex flex-col ${activeAnswerIndex !== null ? 'filter blur-sm' : ''}` }>
           {/* Chat Controls */}
           <div className="p-4 border-b border-border">
-            <div className="flex space-x-2 mb-4">
+            <div className="flex flex-wrap gap-2 mb-4">
               <NewChatCard onClick={startNewChat} />
-              <SearchHistoryCard 
-                chatThreads={chatThreads} 
+              <SearchHistoryCard
+                chatThreads={chatThreads}
                 onSelectThread={selectThread}
                 onDeleteThread={(threadId) => {
                   const updatedThreads = chatThreads.filter(t => t.id !== threadId);
@@ -259,8 +316,8 @@ const ExpertPython = () => {
                     
                     <div className={`flex ${message.isUser ? 'justify-end' : 'justify-start'}`}>
                       <div className={`max-w-[85%] p-3 rounded-2xl ${
-                        message.isUser 
-                          ? 'bg-primary text-primary-foreground ml-4' 
+                        message.isUser
+                          ? 'bg-primary text-primary-foreground ml-4'
                           : message.isRefinement
                           ? 'bg-secondary/20 text-secondary border border-secondary/30 mr-4'
                           : 'bg-accent text-accent-foreground mr-4'
@@ -276,6 +333,14 @@ const ExpertPython = () => {
                         </div>
                       </div>
                     </div>
+                    {!message.isUser && message.answerIndex !== undefined && (
+                      <button
+                        onClick={() => setActiveAnswerIndex(message.answerIndex)}
+                        className="md:hidden mt-2 ml-4 w-[85%] text-left text-sm bg-muted p-3 rounded-lg"
+                      >
+                        {message.previewText}
+                      </button>
+                    )}
                   </div>
                 );
               })}
@@ -318,7 +383,7 @@ const ExpertPython = () => {
         </div>
 
         {/* Right Preview Panel */}
-        <div className="flex-1 bg-background overflow-y-auto p-6">
+        <div className="hidden md:flex md:flex-1 bg-background overflow-y-auto p-6">
           {answers.length === 0 ? (
             <div className="h-full flex items-center justify-center">
               <div className="text-center max-w-2xl">
@@ -441,11 +506,25 @@ const ExpertPython = () => {
         </div>
       </div>
 
+      {activeAnswerIndex !== null && (
+        <div className="fixed inset-0 bg-black/50 z-50 flex items-center justify-center">
+          <div className="bg-card w-[90%] max-h-[90vh] overflow-y-auto rounded-lg p-6 relative">
+            <button
+              onClick={() => setActiveAnswerIndex(null)}
+              className="absolute top-4 right-4 text-muted-foreground"
+            >
+              <X className="w-5 h-5" />
+            </button>
+            {renderAnswerModal(answers[activeAnswerIndex])}
+          </div>
+        </div>
+      )}
+
       {/* Bell Inbox Modal */}
-      <BellInbox 
-        isOpen={showInbox} 
-        onClose={() => setShowInbox(false)} 
-        messages={messages} 
+      <BellInbox
+        isOpen={showInbox}
+        onClose={() => setShowInbox(false)}
+        messages={messages}
         answers={answers} 
       />
     </div>

--- a/client/src/components/Welcome.jsx
+++ b/client/src/components/Welcome.jsx
@@ -1,5 +1,6 @@
 import { useState } from "react";
 import { useLocation } from "wouter";
+import { Menu, X } from "lucide-react";
 import LoginModal from "./LoginModal";
 import ProfileModal from "./ProfileModal";
 
@@ -8,6 +9,7 @@ const Welcome = () => {
   const [showLogin, setShowLogin] = useState(false);
   const [showProfile, setShowProfile] = useState(false);
   const [currentUser, setCurrentUser] = useState(null);
+  const [showMobileMenu, setShowMobileMenu] = useState(false);
 
   const handleLoginSuccess = (userData) => {
     setCurrentUser(userData);
@@ -21,12 +23,13 @@ const Welcome = () => {
   return (
     <div className="min-h-screen bg-background text-foreground">
       {/* Header */}
-      <header className="flex justify-between items-center p-6">
+      <header className="flex justify-between items-center p-6 relative">
         <div className="text-2xl font-bold">
           <span className="text-primary">EXPERT</span>
           <span className="text-secondary ml-2">APP</span>
         </div>
-        <div className="space-x-4">
+        {/* Desktop / Tablet Nav */}
+        <div className="space-x-4 hidden sm:flex">
           <button
             onClick={() => setShowLogin(true)}
             className="px-6 py-2 text-muted-foreground hover:text-foreground transition-colors"
@@ -45,6 +48,34 @@ const Welcome = () => {
           >
             Join as Expert
           </a>
+        </div>
+        {/* Mobile Nav */}
+        <div className="sm:hidden">
+          <button
+            onClick={() => setShowMobileMenu(!showMobileMenu)}
+            className="p-2 rounded-lg hover:bg-accent"
+          >
+            {showMobileMenu ? <X className="w-6 h-6" /> : <Menu className="w-6 h-6" />}
+          </button>
+          {showMobileMenu && (
+            <div className="absolute right-6 top-full mt-2 bg-card border border-border rounded-lg shadow-md flex flex-col w-40 z-50">
+              <button
+                onClick={() => {
+                  setShowMobileMenu(false);
+                  setShowLogin(true);
+                }}
+                className="px-4 py-2 text-left hover:bg-accent rounded-t-lg"
+              >
+                Login
+              </button>
+              <a
+                href="https://fca5f805-1119-45d1-9b1d-44dd46b72e2e-00-3geoz1mc6szkb.kirk.replit.dev/"
+                className="px-4 py-2 hover:bg-accent rounded-b-lg"
+              >
+                Join as Expert
+              </a>
+            </div>
+          )}
         </div>
       </header>
 

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -11,6 +11,7 @@
     "jsx": "preserve",
     "esModuleInterop": true,
     "skipLibCheck": true,
+    "allowJs": true,
     "allowImportingTsExtensions": true,
     "moduleResolution": "bundler",
     "baseUrl": ".",


### PR DESCRIPTION
## Summary
- Add mobile-friendly navbar with hamburger menu showing Login and Join as Expert options
- Make expert chat panels responsive: hide preview pane on mobile, show collapsed response previews with modal popups
- Ensure chat controls wrap cleanly on small screens and allow TypeScript to compile JS modules

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_b_68a4c1dc220c832f822b4b92ea221a89